### PR TITLE
Fix cyclic dependency involving wasm-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,8 +677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["wee_alloc"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
 web-sys = { version = "0.3.5", features = ["console"] }
 js-sys = "0.3.59"
 


### PR DESCRIPTION
This PR fixes a dependency issue when updating Deno in our main repo and is required to unblock the update.

```
error: cyclic package dependency: package `getrandom v0.2.12` depends on itself. Cycle:
package `getrandom v0.2.12`
    ... which satisfies dependency `getrandom = "^0.2.7"` (locked to 0.2.12) of package `ahash v0.8.11`
    ... which satisfies dependency `ahash = "^0.8.6"` (locked to 0.8.11) of package `hashbrown v0.14.3`
    ... which satisfies dependency `hashbrown = "^0.14.1"` (locked to 0.14.3) of package `indexmap v2.2.6`
    ... which satisfies dependency `indexmap = "^2.2.1"` (locked to 2.2.6) of package `serde_json v1.0.115`
    ... which satisfies dependency `serde_json = "^1.0"` (locked to 1.0.115) of package `wasm-bindgen v0.2.92`
    ... which satisfies dependency `wasm-bindgen = "^0.2.92"` (locked to 0.2.92) of package `js-sys v0.3.69`
    ... which satisfies dependency `js-sys = "^0.3"` (locked to 0.3.69) of package `getrandom v0.2.12`
    ... which satisfies dependency `getrandom = "^0.2"` (locked to 0.2.12) of package `rand_core v0.6.4`
    ... which satisfies dependency `rand_core = "^0.6"` (locked to 0.6.4) of package `crypto-common v0.1.6`
    ... which satisfies dependency `crypto-common = "^0.1.4"` (locked to 0.1.6) of package `aead v0.5.2`
```

Also see https://github.com/LIT-Protocol/lit-bls-wasm/pull/3